### PR TITLE
Kludge around unset remotealert_id / toolate_id values

### DIFF
--- a/Ringgroups.class.php
+++ b/Ringgroups.class.php
@@ -30,7 +30,7 @@ class Ringgroups implements \BMO {
 		isset($request['cwignore'])?$cwignore = $request['cwignore']:$cwignore='';
 		isset($request['cpickup'])?$cpickup = $request['cpickup']:$cpickup='';
 		isset($request['cfignore'])?$cfignore = $request['cfignore']:$cfignore='';
-		isset($request['remotealert_id'])?$remotealert_id = $request['remotealert_id']:$remotealert_id='';
+		isset($request['remotealert_id'])?$remotealert_id = $request['remotealert_id']:$remotealert_id='0';
 		isset($request['toolate_id'])?$toolate_id = $request['toolate_id']:$toolate_id='';
 		isset($request['ringing'])?$ringing = $request['ringing']:$ringing='';
 

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -266,8 +266,12 @@ function ringgroups_add($grpnum,$strategy,$grptime,$grplist,$postdest,$desc,$grp
 			}
 		}
 	}
-	//Random error that can crop up, so we fix it here, this probably happens if something went wrong with announcements.
+	// Random error that can crop up, so we fix it here, this probably
+	// happens if something went wrong with announcements.
 	$annmsg_id = (!empty($annmsg_id) && ctype_digit($annmsg_id)) ? $annmsg_id : 0;
+	// XXX: Kludge to force to zero if unset or not numeric
+	$remotealert_id = (!empty($remotealert_id) && ctype_digit($remotealert_id)) ? $remotealert_id : 0;
+	$toolate_id = (!empty($toolate_id) && ctype_digit($toolate_id)) ? $toolate_id : 0;
 
 	$sql = "INSERT INTO ringgroups (grpnum, strategy, grptime, grppre, grplist, annmsg_id, postdest, description, alertinfo, needsconf, remotealert_id, toolate_id, ringing, cwignore, cfignore, cpickup, recording) VALUES ('".$db->escapeSimple($grpnum)."', '".$db->escapeSimple($strategy)."', ".$db->escapeSimple($grptime).", '".$db->escapeSimple($grppre)."', '".$db->escapeSimple($grplist)."', '".$annmsg_id."', '".$db->escapeSimple($postdest)."', '".$db->escapeSimple($desc)."', '".$db->escapeSimple($alertinfo)."', '$needsconf', '$remotealert_id', '$toolate_id', '$ringing', '$cwignore', '$cfignore', '$cpickup', '$recording')";
 	$results = sql($sql);


### PR DESCRIPTION
Similar fix needed to make sure that only integer values get sent via SQL.
