### PR TITLE
fix missing quotes

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -168,10 +168,10 @@ function ringgroups_get_config($engine) {
 						$ext->add($pickupcont,$pickup_code, '', new ext_macro('user-callerid'));
 						$ext->add($pickupcont,$pickup_code, '', new ext_setvar('EXTENS','${FIELDQTY(ALLOWEDMEM,-)}'));
 						$ext->add($pickupcont,$pickup_code, '', new ext_setvar('ITER','1'));
-						$ext->add($pickupcont,$pickup_code, '', new ext_noop('$["${AMPUSER}" == "${CUT(ALLOWEDMEM,-,${ITER})}"]',pickup));
-						$ext->add($pickupcont,$pickup_code, 'extloop', new ext_gotoif('$["${AMPUSER}" == "${CUT(ALLOWEDMEM,-,${ITER})}"]',pickup));
+						$ext->add($pickupcont,$pickup_code, '', new ext_noop('$["${AMPUSER}" == "${CUT(ALLOWEDMEM,-,${ITER})}"]','pickup'));
+						$ext->add($pickupcont,$pickup_code, 'extloop', new ext_gotoif('$["${AMPUSER}" == "${CUT(ALLOWEDMEM,-,${ITER})}"]','pickup'));
 						$ext->add($pickupcont,$pickup_code, '', new ext_set('ITER','$[${ITER}+1]'));
-						$ext->add($pickupcont,$pickup_code, '', new ext_gotoif('$["${ITER}" <= "${EXTENS}"]',extloop));
+						$ext->add($pickupcont,$pickup_code, '', new ext_gotoif('$["${ITER}" <= "${EXTENS}"]','extloop'));
 						$ext->add($pickupcont,$pickup_code, '', new ext_playback('im-sorry&access-denied'));
 						$ext->add($pickupcont,$pickup_code, '', new ext_hangup());
 						$ext->add($pickupcont,$pickup_code, 'pickup', new ext_setvar('PICKUP_EXTEN','${AMPUSER}'));


### PR DESCRIPTION
this was causing an "undefined constant" warning which was halting my system for some reason.

```
$ fwconsole reload
Reloading FreePBX
Error(s) have occured, the following is the retrieve_conf output:
exit: 255
Unable to continue. Use of undefined constant pickup - assumed 'pickup' in /var/www/html/admin/modules/ringgroups/functions.inc.php on line 171
#0 /var/www/html/admin/modules/ringgroups/functions.inc.php(171): Whoops\Run->handleError(8, 'Use of undefine...', '/var/www/html/a...', 171, Array)
#1 /var/www/html/admin/libraries/BMO/DialplanHooks.class.php(95): ringgroups_get_config('asterisk')
#2 /var/lib/asterisk/bin/retrieve_conf(859): FreePBX\DialplanHooks->processHooks('asterisk', Array)
#3 {main}
```