### PR TITLE
Update links

### DIFF
--- a/Api/Gql/Ringgroups.php
+++ b/Api/Gql/Ringgroups.php
@@ -21,6 +21,7 @@ class Ringgroups extends Base {
 						'mutateAndGetPayload' => function ($input) {
 							$res = $this->addRingGroup($input);
 							if(isset($res) && $res == true){
+								needreload();
 								return ['message' => _("Successfully added ringgroup"), 'status'=> true];
 							}else{
 								return ['message' => _("Sorry,Ringgroup already exists"), 'status' => false];
@@ -42,6 +43,7 @@ class Ringgroups extends Base {
 							$response = $this->freepbx->Ringgroups->delete($input['groupNumber']);
 							if(isset($response) && is_int($item)){
 								$this->updateRingGroup($input,$list[$item]);
+								needreload();
 								return ['message' => _("RingGroup updated Successfully"), 'status'=> true];
 							}else{
 								return ['message' => _("Sorry, unable to process your update request"),'status' => false];
@@ -60,6 +62,7 @@ class Ringgroups extends Base {
 						'mutateAndGetPayload' => function ($input) {
 							$response = $this->freepbx->Ringgroups->delete($input['groupNumber']);
 							if(isset($response)){
+								needreload();
 								return ['message' => _("Successfully deleted ringgroup"), 'status'=> true];
 							}else{
 								return ['message' => _("Sorry, unable to process your delete request"),'status' => false];

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ This is a module for [FreePBX©](http://www.freepbx.org/ "FreePBX Home Page"). [
 [FreePBX](http://www.freepbx.org/ "FreePBX Home Page") is a completely modular GUI for Asterisk written in PHP and Javascript. Meaning you can easily write any module you can think of and distribute it free of cost to your clients so that they can take advantage of beneficial features in [Asterisk](http://www.asterisk.org/ "Asterisk Home Page")
 
 ### Setting up a FreePBX system
-[See our WIKI](http://wiki.freepbx.org/display/FOP/Install+FreePBX)
+[See our WIKI](http://sangomakb.atlassian.net/wiki/spaces/FP/pages/9732130/Install+FreePBX)
 ### License
 [This modules code is licensed as GPLv3+](https://www.gnu.org/licenses/gpl-3.0.txt)
 ### Contributing
-To contribute code or modules back into the [FreePBX](http://www.freepbx.org/ "FreePBX Home Page") ecosystem you must fully read our Code License Agreement. We are not able to look at or accept patches or code of any kind until this document is filled out. Please take a look at [http://wiki.freepbx.org/display/DC/Code+License+Agreement](http://wiki.freepbx.org/display/DC/Code+License+Agreement) for more information
+To contribute code or modules back into the [FreePBX](http://www.freepbx.org/ "FreePBX Home Page") ecosystem you must fully read our Code License Agreement. We are not able to look at or accept patches or code of any kind until this document is filled out. Please take a look at [http://sangomakb.atlassian.net/wiki/spaces/FP/pages/10682663/Contributor+License+Agreement](http://sangomakb.atlassian.net/wiki/spaces/FP/pages/10682663/Contributor+License+Agreement) for more information
 ### Issues
-Please file bug reports at http://issues.freepbx.org
+Please file bug reports at http://github.com/FreePBX/issue-tracker/issues


### PR DESCRIPTION
This PR updates the links to the old wiki (wiki.freepbx.org) to the new location (sangomakb.atlassian.net) and updates the settings 'more-info' in the module.xml file

Bugfix FreePBX/issue-tracker#700