### PR TITLE
Refactor addRingGroup and updateRingGroup methods for improved readab…

### DIFF
--- a/Api/Gql/Ringgroups.php
+++ b/Api/Gql/Ringgroups.php
@@ -582,7 +582,6 @@ class Ringgroups extends Base {
 	}
 
 	private function addRingGroup($input){
-
 		$grpnum = $input['groupNumber'];
 		$strategy = $input['strategy'] ?? 'ringall';
 		$grptime = $input['ringTime'] ?? 20;
@@ -592,7 +591,7 @@ class Ringgroups extends Base {
 		$postdest = $input['postAnswer'] ?? 'app-blackhole,hangup,1';
 		$desc = $input['description'] ?? 'ring group'.$grpnum;
 		$alertinfo = $input['alertInfo'] ?? '';
-		$needsconf = (isset($input['needConf']) && $input['needConf'] == true) ?  'CHECKED' : '';
+		$needsconf = isset($input['needConf']) && $input['needConf'] ? 'CHECKED' : '';
 		$remotealert_id = $input['receiverMessageConfirmCall'] ?? 0;
 		$toolate_id = $input['receiverMessage'] ?? 0;
 
@@ -601,34 +600,28 @@ class Ringgroups extends Base {
 			$remotealert_id = $input['recevierMessageConfirmCall'];
 		}
 
-		// Ongoing support of deprecated misspelling
 		if ($toolate_id === 0 && isset($input['recevierMessage'])) {
 			$toolate_id = $input['recevierMessage'];
 		}
 
 		$ringing = $input['ringingMusic'] ?? 'Ring';
-		$cwignore = (isset($input['ignoreCallWait']) && $input['ignoreCallWait'] == true) ? 'CHECKED' : '';
-		$cfignore = (isset($input['ignoreCallForward']) && $input['ignoreCallForward'] == true) ? 'CHECKED' : '';
-		$cpickup = (isset($input['pickupCall']) && $input['pickupCall'] == true) ? 'CHECKED' : '';
+		$cwignore = isset($input['ignoreCallWait']) && $input['ignoreCallWait'] ? 'CHECKED' : '';
+		$cfignore = isset($input['ignoreCallForward']) && $input['ignoreCallForward'] ? 'CHECKED' : '';
+		$cpickup = isset($input['pickupCall']) && $input['pickupCall'] ? 'CHECKED' : '';
 		$recording = $input['callRecording'] ?? 'dontcare';
-		$progress = (isset($input['callProgress']) &&  $input['callProgress'] == true) ? 'yes' : 'no';
-		$elsewhere = (isset($input['answeredElseWhere']) && $input['answeredElseWhere'] == true) ? 'yes' : 'no';
+		$progress = isset($input['callProgress']) && $input['callProgress'] ? 'yes' : 'no';
+		$elsewhere = isset($input['answeredElseWhere']) && $input['answeredElseWhere'] ? 'yes' : 'no';
 		$rvolume = $input['overrideRingerVolume'] ?? '';
 		$changecid = $input['changecid'] ?? "default";
 		if(!in_array($changecid,["fixed", "extern", "did", "forcedid"])) {
 			$changecid = "default";
 		}
 		$fixedcid = $input['fixedcid'] ?? "";
-		
+
 		return $this->freepbx->Ringgroups->add($grpnum,$strategy,$grptime,$grplist,$postdest,$desc,$grppre,$annmsg_id,$alertinfo,$needsconf,$remotealert_id,$toolate_id,$ringing,$cwignore,$cfignore,$changecid,$fixedcid,$cpickup, $recording,$progress,$elsewhere,$rvolume,1);
 	}
-		
-	/**
-  * updateRingGroup
-  *
-  * @return void
-  */
- private function updateRingGroup(mixed $input,$res){
+
+	private function updateRingGroup(mixed $input,$res){
 		$grpnum = $input['groupNumber'];
 		$strategy = $input['strategy'] ?? $res['strategy'];
 		$grptime = $input['ringTime'] ?? $res['grptime'];
@@ -638,7 +631,7 @@ class Ringgroups extends Base {
 		$postdest = $input['postAnswer'] ?? $res['postdest'];
 		$desc = $input['description'] ?? $res['description'];
 		$alertinfo = $input['alertInfo'] ?? $res['alertinfo'];
-		$needsconf = $input['needConf'] ?? $res['needsconf'];
+		$needsconf = isset($input['needConf']) && $input['needConf'] ? 'CHECKED' : $res['needsconf'];
 		$remotealert_id = $input['receiverMessageConfirmCall'] ?? $res['remotealert_id'];
 		$toolate_id = $input['receiverMessage'] ?? $res['toolate_id'];
 
@@ -647,18 +640,17 @@ class Ringgroups extends Base {
 			$remotealert_id = $input['recevierMessageConfirmCall'];
 		}
 
-		// Ongoing support of deprecated misspelling
 		if ($toolate_id === $res['toolate_id'] && isset($input['recevierMessage'])) {
 			$toolate_id = $input['recevierMessage'];
 		}
 
 		$ringing = $input['ringingMusic'] ?? $res['ringing'];
-		$cwignore = $input['ignoreCallWait'] ?? $res['cwignore'];
-		$cfignore = $input['ignoreCallForward'] ?? $res['cfignore'];
-		$cpickup = $input['pickupCall'] ?? $res['cpickup'];
+		$cwignore = isset($input['ignoreCallWait']) && $input['ignoreCallWait'] ? 'CHECKED' : $res['cwignore'];
+		$cfignore = isset($input['ignoreCallForward']) && $input['ignoreCallForward'] ? 'CHECKED' : $res['cfignore'];
+		$cpickup = isset($input['pickupCall']) && $input['pickupCall'] ? 'CHECKED' : $res['cpickup'];
 		$recording = $input['callRecording'] ?? $res['recording'];
-		$progress = $input['callProgress'] ?? $res['progress'];
-		$elsewhere = $input['answeredElseWhere'] ?? $res['elsewhere'];
+		$progress = isset($input['callProgress']) && $input['callProgress'] ? 'yes' : $res['progress'];
+		$elsewhere = isset($input['answeredElseWhere']) && $input['answeredElseWhere'] ? 'yes' : $res['elsewhere'];
 		$rvolume = $input['overrideRingerVolume'] ?? $res['rvolume'];
 
 		$changecid = $input['changecid'] ?? $res['changecid'];
@@ -666,7 +658,7 @@ class Ringgroups extends Base {
 			$changecid = "default";
 		}
 		$fixedcid = $input['fixedcid'] ?? $res['fixedcid'];
-		
+
 		return $this->freepbx->Ringgroups->add($grpnum,$strategy,$grptime,$grplist,$postdest,$desc,$grppre,$annmsg_id,$alertinfo,$needsconf,$remotealert_id,$toolate_id,$ringing,$cwignore,$cfignore,$changecid,$fixedcid,$cpickup, $recording,$progress,$elsewhere,$rvolume,1);
 	}
 


### PR DESCRIPTION
# Issue
This pull request addresses the issue where certain boolean options in Ring Group configurations are incorrectly processed when using the GQL API in FreePBX. These options, such as `needConf`, `ignoreCallWait`, `ignoreCallForward`, and `pickupCall`, are not being correctly serialized, leading to configuration discrepancies or missing values in the backend.

## Problem
When creating or updating a Ring Group via the internal GQL API, boolean options like `needConf`, `ignoreCallWait`, `ignoreCallForward`, and `pickupCall` may receive incorrect values such as `false` or `null` due to improper handling in the backend logic. These fields expect specific values like `"CHECKED"` or an empty string (`""`), or `"yes"` or `"no"`, but when `null` coalescing operators (`??`) are used or when no value is provided, the backend incorrectly processes them.

This issue leads to missing or misrepresented configurations, which may affect essential call behaviors, such as call confirmation or call pickup restrictions.

## Solution
### Modifications to `addRingGroup` and `updateRingGroup` Methods
1. Updated the methods to handle boolean options correctly by explicitly checking for the presence of these options.
2. Replaced the use of null coalescing (`??`) for boolean options with conditional logic that sets the values to `"CHECKED"` or `""` for checkboxes, and `"yes"` or `"no"` for binary flags.
3. Ensured that legacy or misspelled field names are still supported for backward compatibility.

### Updated Code:
In `addRingGroup`:
```php
$needsconf = isset($input['needConf']) && $input['needConf'] ? 'CHECKED' : '';
$cwignore = isset($input['ignoreCallWait']) && $input['ignoreCallWait'] ? 'CHECKED' : '';
$cfignore = isset($input['ignoreCallForward']) && $input['ignoreCallForward'] ? 'CHECKED' : '';
$cpickup = isset($input['pickupCall']) && $input['pickupCall'] ? 'CHECKED' : '';
$progress = isset($input['callProgress']) && $input['callProgress'] ? 'yes' : 'no';
$elsewhere = isset($input['answeredElseWhere']) && $input['answeredElseWhere'] ? 'yes' : 'no';
```

In `updateRingGroup`:
```php
$needsconf = isset($input['needConf']) && $input['needConf'] ? 'CHECKED' : $res['needsconf'];
$cwignore = isset($input['ignoreCallWait']) && $input['ignoreCallWait'] ? 'CHECKED' : $res['cwignore'];
$cfignore = isset($input['ignoreCallForward']) && $input['ignoreCallForward'] ? 'CHECKED' : $res['cfignore'];
$cpickup = isset($input['pickupCall']) && $input['pickupCall'] ? 'CHECKED' : $res['cpickup'];
$progress = isset($input['callProgress']) && $input['callProgress'] ? 'yes' : $res['progress'];
$elsewhere = isset($input['answeredElseWhere']) && $input['answeredElseWhere'] ? 'yes' : $res['elsewhere'];
```

### Changes Made
1. In the addRingGroup method: Explicit handling of boolean options like needConf, ignoreCallWait, ignoreCallForward, and pickupCall with correct values ("CHECKED" or "").
2. In the updateRingGroup method: Similar improvements in handling boolean options during the update operation to ensure values like needConf, ignoreCallWait, ignoreCallForward, and pickupCall are serialized correctly.

3. Support for Legacy/Misspelled Field Names: Retained compatibility for any legacy or misspelled field names, such as recevierMessageConfirmCall and recevierMessage.

### Testing
- Created a Ring Group via the GQL API with various boolean options set to false or omitted.
- Verified that the Ring Group configuration persisted correctly with needConf, ignoreCallWait, ignoreCallForward, and pickupCall values correctly serialized as "CHECKED", "", "yes", or "no".
- Inspected the Ring Group configuration in the FreePBX GUI and database to ensure the boolean options were processed as expected.

### Conclusion
This pull request resolves the issue with boolean options in Ring Group configurations by ensuring that these options are serialized correctly when creating or updating a Ring Group via the GQL API. The fix improves the reliability of call handling configurations in FreePBX.

Please let me know if any further modifications or clarifications are needed. Thank you for reviewing this merge request!